### PR TITLE
 Ingress apiversion changed

### DIFF
--- a/botfront/templates/botfront-app-ingress.yaml
+++ b/botfront/templates/botfront-app-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.botfront.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-app-ingress


### PR DESCRIPTION
API version for Ingress changed to networking.k8s.io/v1 as per the documentation. Facing error with extensions/v1beta1